### PR TITLE
「Issueの内容を変更/削除するAPIを追加」のissueの実装をしました

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,9 @@ gem 'puma', '~> 3.7'
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 # gem 'rack-cors'
 
+# Use paranoia as soft delete
+gem "paranoia", "~> 2.2"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,8 @@ GEM
     nio4r (2.1.0)
     nokogiri (1.8.1)
       mini_portile2 (~> 2.3.0)
+    paranoia (2.3.1)
+      activerecord (>= 4.0, < 5.2)
     pg (0.21.0)
     puma (3.10.0)
     rack (2.0.3)
@@ -179,6 +181,7 @@ DEPENDENCIES
   coveralls
   factory_girl_rails (~> 4.0)
   listen (>= 3.0.5, < 3.2)
+  paranoia (~> 2.2)
   pg
   puma (~> 3.7)
   rails (~> 5.1.4)

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -13,9 +13,14 @@ class IssuesController < ApplicationController
     end
   end
 
+  def destroy
+    Issue.find(params[:id]).destroy
+    render_ok(issue)
+  end
+
   private
 
   def issue_params
-    params.permit(:title, :body, :status)
+    params.require(:issue).permit(:title, :body, :status)
   end
 end

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -23,7 +23,8 @@ class IssuesController < ApplicationController
   end
 
   def destroy
-    Issue.find(params[:id]).destroy
+    issue = Issue.find(params[:id])
+    issue.destroy
     render_ok(issue)
   end
 

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -13,9 +13,23 @@ class IssuesController < ApplicationController
     end
   end
 
+  def update
+    issue = Issue.find(params[:id])
+    if issue.update_attributes(issue_params)
+      render_ok(issue)
+    else
+      render_ng(400, issue.errors)
+    end
+  end
+
+  def destroy
+    Issue.find(params[:id]).destroy
+    render_ok(issue)
+  end
+
   private
 
   def issue_params
-    params.permit(:title, :body, :status)
+    params.require(:issue).permit(:title, :body, :status)
   end
 end

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -13,6 +13,15 @@ class IssuesController < ApplicationController
     end
   end
 
+  def update
+    issue = Issue.find(params[:id])
+    if issue.update_attributes(issue_params)
+      render_ok(issue)
+    else
+      render_ng(400, issue.errors)
+    end
+  end
+
   def destroy
     Issue.find(params[:id]).destroy
     render_ok(issue)

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -13,23 +13,9 @@ class IssuesController < ApplicationController
     end
   end
 
-  def update
-    issue = Issue.find(params[:id])
-    if issue.update_attributes(issue_params)
-      render_ok(issue)
-    else
-      render_ng(400, issue.errors)
-    end
-  end
-
-  def destroy
-    Issue.find(params[:id]).destroy
-    render_ok(issue)
-  end
-
   private
 
   def issue_params
-    params.require(:issue).permit(:title, :body, :status)
+    params.permit(:title, :body, :status)
   end
 end

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -1,3 +1,4 @@
 class Issue < ApplicationRecord
+  acts_as_paranoid
   enum status: { keep: 0, problem: 1, try: 2 }
 end

--- a/db/migrate/20171015135108_add_deleted_at_to_issues.rb
+++ b/db/migrate/20171015135108_add_deleted_at_to_issues.rb
@@ -1,0 +1,6 @@
+class AddDeletedAtToIssues < ActiveRecord::Migration[5.1]
+  def change
+    add_column :issues, :deleted_at, :datetime
+    add_index :issues, :deleted_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171015040241) do
+
+ActiveRecord::Schema.define(version: 20171015135108) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +22,8 @@ ActiveRecord::Schema.define(version: 20171015040241) do
     t.integer "status", default: 1
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
+    t.index ["deleted_at"], name: "index_issues_on_deleted_at"
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171011061754) do
+ActiveRecord::Schema.define(version: 20171015135108) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -18,9 +18,11 @@ ActiveRecord::Schema.define(version: 20171011061754) do
   create_table "issues", force: :cascade do |t|
     t.string "title"
     t.text "body"
-    t.integer "status"
+    t.integer "status", default: 1
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
+    t.index ["deleted_at"], name: "index_issues_on_deleted_at"
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
-ActiveRecord::Schema.define(version: 20171015135108) do
+ActiveRecord::Schema.define(version: 20171015040241) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,8 +21,6 @@ ActiveRecord::Schema.define(version: 20171015135108) do
     t.integer "status", default: 1
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.datetime "deleted_at"
-    t.index ["deleted_at"], name: "index_issues_on_deleted_at"
   end
 
 end

--- a/spec/controllers/issues_controller_spec.rb
+++ b/spec/controllers/issues_controller_spec.rb
@@ -34,19 +34,4 @@ RSpec.describe IssuesController, type: :controller do
       it { expect(JSON.parse(subject.body)['message']['title']).to eq ["can't be blank"]}
     end
   end
-
-  describe "#update" do
-    let(:issue_attrs) {FactoryGirl.create(:issue)}
-    let(:issue_update_attrs) {FactoryGirl.attributes_for(:issue_update)}
-    subject { patch :update, params: { id: issue_attrs, issue: issue_update_attrs }}
-    it { expect(subject.status).to eq 200 }
-    it { expect(JSON.parse(subject.body)['payload']['body']).to eq issue_update_attrs[:body] }
-  end
-
-  describe "#destroy" do
-    let(:issue_attrs) {FactoryGirl.create(:issue)}
-    let(:issue) {delete :destroy, params: {id: issue_attrs}}
-    subject {get :index}
-    it {expect(JSON.parse(subject.body)['payload'].map {|d| d['id']}).not_to include issue_attrs[:id]}
-  end
 end

--- a/spec/controllers/issues_controller_spec.rb
+++ b/spec/controllers/issues_controller_spec.rb
@@ -13,6 +13,13 @@ RSpec.describe IssuesController, type: :controller do
     let(:issue_attrs) {  FactoryGirl.attributes_for(:issue).keep_if { |k, v| k =~ /body|title|status/ } }
     subject { put :create, params: { issue: issue_attrs } }
     it { expect(subject.status).to eq 200 }
-    it { expect(JSON.parse(subject.body)['payload']['body']).to eq issue_attrs['body'] }
+    it { expect(JSON.parse(subject.body)['payload']['body']).to eq issue_attrs[:body] }
+  end
+
+  describe "#destroy" do
+    let(:issue_attrs) {FactoryGirl.create(:issue)}
+    let(:issue) {delete :destroy, params: {id: issue_attrs}}
+    subject {get :index}
+    it {expect(JSON.parse(subject.body)['payload'].map {|d| d['id']}).not_to include issue_attrs[:id]}
   end
 end

--- a/spec/controllers/issues_controller_spec.rb
+++ b/spec/controllers/issues_controller_spec.rb
@@ -16,6 +16,14 @@ RSpec.describe IssuesController, type: :controller do
     it { expect(JSON.parse(subject.body)['payload']['body']).to eq issue_attrs[:body] }
   end
 
+  describe "#update" do
+    let(:issue_attrs) {FactoryGirl.create(:issue)}
+    let(:issue_update_attrs) {FactoryGirl.attributes_for(:issue_update)}
+    subject { patch :update, params: { id: issue_attrs, issue: issue_update_attrs }}
+    it { expect(subject.status).to eq 200 }
+    it { expect(JSON.parse(subject.body)['payload']['body']).to eq issue_update_attrs[:body] }
+  end
+
   describe "#destroy" do
     let(:issue_attrs) {FactoryGirl.create(:issue)}
     let(:issue) {delete :destroy, params: {id: issue_attrs}}

--- a/spec/controllers/issues_controller_spec.rb
+++ b/spec/controllers/issues_controller_spec.rb
@@ -20,14 +20,14 @@ RSpec.describe IssuesController, type: :controller do
   describe "#create" do
     context '正常登録' do
       let(:issue_attrs) {  FactoryGirl.attributes_for(:issue).keep_if { |k, v| k =~ /body|title|status/ } }
-      subject { put :create, params: issue_attrs }
+      subject { put :create, params: { issue: issue_attrs }}
       it_behaves_like 'status_is_ok'
       it { expect(JSON.parse(subject.body)['payload']['body']).to eq issue_attrs[:body] }
     end
 
     context 'タイトルの必須NG' do
       let(:issue_attrs) {  FactoryGirl.attributes_for(:issue).keep_if { |k, v| k =~ /body|status/ } }
-      subject { put :create, params: issue_attrs }
+      subject { put :create, params: { issue: issue_attrs }}
       it_behaves_like 'status_is_bad_request'
       it { expect(JSON.parse(subject.body)['status']).to eq 'ng' }
       it { expect(JSON.parse(subject.body)['error_code']).to eq 400 }

--- a/spec/controllers/issues_controller_spec.rb
+++ b/spec/controllers/issues_controller_spec.rb
@@ -34,4 +34,19 @@ RSpec.describe IssuesController, type: :controller do
       it { expect(JSON.parse(subject.body)['message']['title']).to eq ["can't be blank"]}
     end
   end
+
+  describe "#update" do
+    let(:issue_attrs) {FactoryGirl.create(:issue)}
+    let(:issue_update_attrs) {FactoryGirl.attributes_for(:issue_update)}
+    subject { patch :update, params: { id: issue_attrs, issue: issue_update_attrs }}
+    it { expect(subject.status).to eq 200 }
+    it { expect(JSON.parse(subject.body)['payload']['body']).to eq issue_update_attrs[:body] }
+  end
+
+  describe "#destroy" do
+    let(:issue_attrs) {FactoryGirl.create(:issue)}
+    let(:issue) {delete :destroy, params: {id: issue_attrs}}
+    subject {get :index}
+    it {expect(JSON.parse(subject.body)['payload'].map {|d| d['id']}).not_to include issue_attrs[:id]}
+  end
 end

--- a/spec/factories/issues.rb
+++ b/spec/factories/issues.rb
@@ -4,4 +4,10 @@ FactoryGirl.define do
     body '問題のbody'
     status :problem
   end
+
+  factory :issue_update, class: Issue do
+    title "トライに更新しました"
+    body 'トライにbodyを更新しました'
+    status :try
+  end
 end


### PR DESCRIPTION
@ukitazume @aki-tate 
「Issueの内容を変更/削除するAPIを追加」のissueの実装です。
ご確認のほど、よろしくお願いいたします。

またgemに関してですがissueで相談させていただいたものから
変更いたしました、事後報告となり申し訳ありません
（確認したところ利用数が少なかったのが気になったため）

## 「paranoia」gemの選定理由
大きな理由としては以下の３点です。

1.  githubが存在すること
1.  直近１年での運用があること
1.  利用数が多いこと

理由の詳細は以下です。

### githubが存在すること
https://github.com/rubysherpas/paranoia

README.mdにUsageがしっかりと書かれていることを確認

### 直近１年での運用があること
主に以下の３点を確認しました。
1. コミットログがあることを確認
1. PRが処理されていることを確認
1. Rails5に対応していることを確認

### 利用数が多いこと
以下３点で多いことを確認しました

1. gemのDL数
http://bestgems.org/gems/paranoia
1. The Ruby Toolbox での soft deleteカテゴリでスコアが一番高い
https://www.ruby-toolbox.com/categories/active_record_soft_delete
1. githubのstarが2000以上あること

以上です
