### PR TITLE
Issueサーチ機能・ソート機能の追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,9 @@ gem 'puma', '~> 3.7'
 # Use paranoia as soft delete
 gem "paranoia", "~> 2.2"
 
+#Use ransack for search query
+gem "ransack", "~> 1.8.7"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,8 @@ GEM
     parser (2.4.0.2)
       ast (~> 2.3)
     pg (0.21.0)
+    polyamorous (1.3.3)
+      activerecord (>= 3.0)
     powerpack (0.1.1)
     puma (3.10.0)
     rack (2.0.3)
@@ -123,6 +125,12 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (3.0.0)
     rake (12.1.0)
+    ransack (1.8.7)
+      actionpack (>= 3.0)
+      activerecord (>= 3.0)
+      activesupport (>= 3.0)
+      i18n
+      polyamorous (~> 1.3.2)
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
@@ -200,6 +208,7 @@ DEPENDENCIES
   pg
   puma (~> 3.7)
   rails (~> 5.1.4)
+  ransack (~> 1.8.7)
   rspec-rails (~> 3.6)
   rubocop
   simplecov (~> 0.14.1)
@@ -211,4 +220,4 @@ RUBY VERSION
    ruby 2.5.0p-1
 
 BUNDLED WITH
-   1.15.4
+   1.16.1

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -1,6 +1,7 @@
 class IssuesController < ApplicationController
   def index
-    render_ok(Issue.all)
+    @q = Issue.ransack(params[:q])
+    render_ok(@q.result)
   end
 
   def create

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -3,4 +3,6 @@ class Issue < ApplicationRecord
   validates :title, presence: true
 
   enum status: { keep: 0, problem: 1, try: 2 }
+  # be able to search with string
+  ransacker :status, formatter: proc { |v| statuses[v] }
 end

--- a/spec/controllers/issues_controller_spec.rb
+++ b/spec/controllers/issues_controller_spec.rb
@@ -10,10 +10,25 @@ RSpec.describe IssuesController, type: :controller do
   end
 
   describe "#index" do
-    let!(:issue) { create :issue }
-    subject { get :index }
-    it_behaves_like 'status_is_ok'
-    it { expect(JSON.parse(subject.body)['payload'].map { |d| d['id'] }).to include issue.id }
+    context "default" do
+      let!(:issue) { create :issue }
+      subject { get :index }
+      it_behaves_like 'status_is_ok'
+      it { expect(JSON.parse(subject.body)['payload'].map { |d| d['id'] }).to include issue.id }
+    end
+    context "filter by status" do
+      let!(:issues_searched) { create_list :issue, 10, title: "the string to be searched", status: :keep }
+      subject { get :index, params: { q: { status_eq: "keep", title_cont: "to be searched" } } }
+      it_behaves_like 'status_is_ok'
+      it { expect(JSON.parse(subject.body)["payload"].map { |d| d["status"] }).to all(eq "keep") }
+      it { expect(JSON.parse(subject.body)["payload"].map { |d| d["title"] }).to all(include "to be searched") }
+    end
+    context "order by updated time" do
+      let!(:issue_latest) { create_list(:issue, 10).last }
+      subject { get :index, params: { q: { s: ["updated_at desc"] } } }
+      it_behaves_like 'status_is_ok'
+      it { expect(JSON.parse(subject.body)["payload"].first["id"]).to eq issue_latest.id }
+    end
   end
 
   describe "#create" do

--- a/spec/controllers/issues_controller_spec.rb
+++ b/spec/controllers/issues_controller_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe IssuesController, type: :controller do
       let!(:issues_searched) { create_list :issue, 10, title: "the string to be searched", status: :keep }
       subject { get :index, params: { q: { status_eq: "keep", title_cont: "to be searched" } } }
       it_behaves_like 'status_is_ok'
+      it { expect(JSON.parse(subject.body)["payload"].count).to be >= 10 }
       it { expect(JSON.parse(subject.body)["payload"].map { |d| d["status"] }).to all(eq "keep") }
       it { expect(JSON.parse(subject.body)["payload"].map { |d| d["title"] }).to all(include "to be searched") }
     end


### PR DESCRIPTION
@ukitazume 
[#14](https://github.com/sitateru/kpt/issues/14)/[#16](https://github.com/sitateru/kpt/issues/16)の対応です。
ransack導入でソート対応も包含できましたので、PRまとめました。
検索とソートの代表ケースをテストに追加しています。