### PR TITLE
Dockerコンテナ化

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+DB_HOST=db

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
 FROM ruby:2.5.1-alpine3.7
 
-RUN apk update && \
-  apk add --no-cache libstdc++ postgresql-dev tzdata
-
 RUN mkdir /myapp
 WORKDIR /myapp
 COPY Gemfile /myapp/Gemfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM ruby:2.5.1-alpine3.7
+
+RUN apk update && \
+  apk add --no-cache libstdc++ postgresql-dev tzdata
+
+RUN mkdir /myapp
+WORKDIR /myapp
+COPY Gemfile /myapp/Gemfile
+COPY Gemfile.lock /myapp/Gemfile.lock
+
+RUN set -ex && \
+  apk update && \
+  apk add --no-cache libstdc++ postgresql-dev tzdata build-base bash && \
+  bundle install --no-cache && \
+  apk del build-base
+
+COPY . /myapp

--- a/README.md
+++ b/README.md
@@ -30,6 +30,24 @@ KPT用のApplicaitonを作成するためのWebAPI
 
 localhost:8000 にアクセス
 
+## Getting Start(for Docker)
+
+- `$ cd ${this_repo}`
+- `$ docker-compose build`
+- .envファイルにDBのendpointを記入。
+
+  ```
+  DB_HOST=172.17.0.1 
+  ```
+
+- db用コンテナを使用する場合
+ - .envに`DB_HOST=db`を記入。
+ - `$ mkdir -p tmp/db`を実行。(ホストのマウントポイント)
+- `$ docker-compose up -d`
+- `$ docker ps`
+- `$ docker-compose run web rake db:create db:migrate`
+
+localhost:8000 にアクセス
 
 ## 参考資料
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -8,7 +8,8 @@ default: &default
   adapter: postgresql
   encoding: unicode
   username: postgres
-  password:
+  password: 
+  host: <%= ENV.fetch("DB_HOST") { 'localhost' } %>
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   timeout: 5000
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '2'
+services:
+  db:
+    image: postgres:10.4-alpine
+    ports:
+      - "5432"
+    volumes:
+      - ./tmp/db:/var/lib/postgresql/data:z
+  web:
+    build: .
+    command: bash -c "echo 'DB_HOST=${DB_HOST}' && bundle exec rails s -p 8000 -b '0.0.0.0'"
+    volumes:
+      - .:/myapp:z
+    ports:
+      - "8000:8000"
+    depends_on:
+      - db
+    environment:
+      DB_HOST: $DB_HOST


### PR DESCRIPTION
#24  に対応

要件
- ローカルでdocker上にてAPIが動く
- なるべく軽量
- 使い方をREAMEに追記
- os は自由

仕様
- api用コンテナとdb用コンテナの２つが起動する。
  - api用コンテナのOSイメージはruby:2.5.1-alpine3.7(61.5MB)
    ビルド後のイメージは現在のGemfileで236MB 
  - db用コンテナのOSイメージはpostgres:10.4-alpine(39.5 MB)
- DBへの接続については、.envファイルのDB_HOSTにDBのendpointを記入する。
  - dbコンテナを使用する場合は、`DB_HOST=db`と記入。

懸念点
 - db用コンテナが不要の場合も、無駄にdbコンテナが起動してしまう。
 - dbコンテナが全く不要な場合は、docker-composeは使わない方がシンプル。
   - api用コンテナの環境変数にDBのendpointを渡した後に、railsアプリケーションを起動するように、Dockerfileを修正する必要あり