### PR TITLE
#36 OpenしているIssueにアサインされているUserを削除できないように修正

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -28,8 +28,11 @@ class UsersController < ApplicationController
 
   def destroy
     user = User.find(params[:id])
-    user.destroy
-    render_ok(user)
+    if user.destroy
+      render_ok(user)
+    else
+      render_ng(400, user.errors)
+    end
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  before_destroy :do_not_destroy_open_issue
+
   # for soft delete
   acts_as_paranoid
   has_many :assignments
@@ -7,4 +9,13 @@ class User < ApplicationRecord
   validates :name, presence: true, uniqueness: { scope: :deleted_at }
   # not strictly
   validates :email, presence: true, format: { with: /\A[^@\s]+@[^@\s]+\z/ }
+
+  private
+
+  def do_not_destroy_open_issue
+    return unless issues.pluck(:is_closed).include?(false)
+
+    errors[:user] << 'This user is assigned to an open issue'
+    throw(:abort)
+  end
 end


### PR DESCRIPTION
#36 の対応をしました。

実装内容
- User削除時に紐付いているIssueをチェックして一つでもOpenになっているIssueがあればエラーになるように修正
- specの追加・修正