### PR TITLE
#32 ユーザグループを追加する

### DIFF
--- a/app/controllers/group_users_controller.rb
+++ b/app/controllers/group_users_controller.rb
@@ -1,0 +1,2 @@
+class GroupUsersController < ApplicationController
+end

--- a/app/controllers/group_users_controller.rb
+++ b/app/controllers/group_users_controller.rb
@@ -1,2 +1,19 @@
 class GroupUsersController < ApplicationController
+  def show
+    group = Group.find(params[:group_id])
+    render_ok(group.users)
+  end
+
+  def update
+    group = Group.find(params[:group_id])
+    if group.update(group_users_params)
+      render_ok(group.users)
+    else
+      render_ng(400, group.errors)
+    end
+  end
+
+  def group_users_params
+    params.require(:group).permit(user_ids: [])
+  end
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,0 +1,2 @@
+class GroupsController < ApplicationController
+end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,2 +1,43 @@
 class GroupsController < ApplicationController
+  def index
+    render_ok(JSON.parse(Group.all.includes(:users).to_json(include: :users)))
+  end
+
+  def show
+    group = Group.find(params[:id])
+    render_ok(JSON.parse(group.to_json(include: :users)))
+  end
+
+  def create
+    group = Group.new(group_params)
+    if group.save
+      render_ok(JSON.parse(group.to_json(include: :users)))
+    else
+      render_ng(400, group.errors)
+    end
+  end
+
+  def update
+    group = Group.find(params[:id])
+    if group.update(group_params)
+      render_ok(JSON.parse(group.to_json(include: :users)))
+    else
+      render_ng(400, group.errors)
+    end
+  end
+
+  def destroy
+    group = Group.find(params[:id])
+    if group.destroy
+      render_ok(group)
+    else
+      render_ng(400, group.errors)
+    end
+  end
+
+  private
+
+  def group_params
+    params.require(:group).permit(:name)
+  end
 end

--- a/app/controllers/user_groups_controller.rb
+++ b/app/controllers/user_groups_controller.rb
@@ -1,0 +1,2 @@
+class UserGroupsController < ApplicationController
+end

--- a/app/controllers/user_groups_controller.rb
+++ b/app/controllers/user_groups_controller.rb
@@ -1,2 +1,21 @@
 class UserGroupsController < ApplicationController
+  def show
+    user = User.find(params[:user_id])
+    render_ok(user.groups)
+  end
+
+  def update
+    user = User.find(params[:user_id])
+    if user.update(user_groups_params)
+      render_ok(user.groups)
+    else
+      render_ng(400, user.errors)
+    end
+  end
+
+  private
+
+  def user_groups_params
+    params.require(:user).permit(group_ids: [])
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,17 +1,17 @@
 class UsersController < ApplicationController
   def index
-    render_ok(JSON.parse(User.all.includes(:issues).to_json(include: :issues)))
+    render_ok(JSON.parse(User.all.includes([:issues, :groups]).to_json(include: [:issues, :groups])))
   end
 
   def show
     user = User.find(params[:id])
-    render_ok(JSON.parse(user.to_json(include: :issues)))
+    render_ok(JSON.parse(user.to_json(include: [:issues, :groups])))
   end
 
   def create
     user = User.new(user_params)
     if user.save
-      render_ok(user)
+      render_ok(JSON.parse(user.to_json(include: :groups)))
     else
       render_ng(400, user.errors)
     end
@@ -20,7 +20,7 @@ class UsersController < ApplicationController
   def update
     user = User.find(params[:id])
     if user.update(user_params)
-      render_ok(user)
+      render_ok(JSON.parse(user.to_json(include: :groups)))
     else
       render_ng(400, user.errors)
     end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,0 +1,2 @@
+class Group < ApplicationRecord
+end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,2 +1,4 @@
 class Group < ApplicationRecord
+  has_many :group_users, dependent: :destroy
+  has_many :users, through: :group_users
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,4 +1,6 @@
 class Group < ApplicationRecord
   has_many :group_users, dependent: :destroy
   has_many :users, through: :group_users
+
+  validates :name, presence: true
 end

--- a/app/models/group_user.rb
+++ b/app/models/group_user.rb
@@ -1,0 +1,4 @@
+class GroupUser < ApplicationRecord
+  belongs_to :group
+  belongs_to :user
+end

--- a/app/models/group_user.rb
+++ b/app/models/group_user.rb
@@ -1,4 +1,6 @@
 class GroupUser < ApplicationRecord
   belongs_to :group
   belongs_to :user
+
+  validates :group_id, uniqueness: { scope: :user_id }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,8 @@ class User < ApplicationRecord
   acts_as_paranoid
   has_many :assignments # rubocop:disable Rails/HasManyOrHasOneDependent
   has_many :issues, through: :assignments
+  has_many :group_users, dependent: :destroy
+  has_many :groups, through: :group_users
 
   validates :name, presence: true, uniqueness: { scope: :deleted_at }
   # not strictly

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,4 +10,5 @@ Rails.application.routes.draw do
 
   resources :assignments, only: [:index, :create, :destroy]
   resources :users
+  resources :groups
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,10 @@ Rails.application.routes.draw do
   end
 
   resources :assignments, only: [:index, :create, :destroy]
-  resources :users
-  resources :groups
+  resources :users do
+    resource :groups, controller: 'user_groups', only: [:show, :update]
+  end
+  resources :groups do
+    resource :users, controller: 'group_users', only: [:show, :update]
+  end
 end

--- a/db/migrate/20190602163106_create_groups.rb
+++ b/db/migrate/20190602163106_create_groups.rb
@@ -1,0 +1,9 @@
+class CreateGroups < ActiveRecord::Migration[5.1]
+  def change
+    create_table :groups do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190602164923_create_group_users.rb
+++ b/db/migrate/20190602164923_create_group_users.rb
@@ -5,6 +5,8 @@ class CreateGroupUsers < ActiveRecord::Migration[5.1]
       t.references :user, foreign_key: true, null: false
 
       t.timestamps
+
+      t.index [:group_id, :user_id], unique: true
     end
   end
 end

--- a/db/migrate/20190602164923_create_group_users.rb
+++ b/db/migrate/20190602164923_create_group_users.rb
@@ -1,0 +1,10 @@
+class CreateGroupUsers < ActiveRecord::Migration[5.1]
+  def change
+    create_table :group_users do |t|
+      t.references :group, foreign_key: true, null: false
+      t.references :user, foreign_key: true, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190508234320) do
+ActiveRecord::Schema.define(version: 20190602164923) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,22 @@ ActiveRecord::Schema.define(version: 20190508234320) do
     t.index ["issue_id", "user_id"], name: "index_assignments_on_issue_id_and_user_id", unique: true
     t.index ["issue_id"], name: "index_assignments_on_issue_id"
     t.index ["user_id"], name: "index_assignments_on_user_id"
+  end
+
+  create_table "group_users", force: :cascade do |t|
+    t.bigint "group_id", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["group_id", "user_id"], name: "index_group_users_on_group_id_and_user_id", unique: true
+    t.index ["group_id"], name: "index_group_users_on_group_id"
+    t.index ["user_id"], name: "index_group_users_on_user_id"
+  end
+
+  create_table "groups", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "issues", force: :cascade do |t|
@@ -48,4 +64,6 @@ ActiveRecord::Schema.define(version: 20190508234320) do
 
   add_foreign_key "assignments", "issues"
   add_foreign_key "assignments", "users"
+  add_foreign_key "group_users", "groups"
+  add_foreign_key "group_users", "users"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -17,6 +17,6 @@ Assignment.create(issue_id: 1, user_id: 1)
 Assignment.create(issue_id: 2, user_id: 1)
 Assignment.create(issue_id: 2, user_id: 2)
 
-Group.create(name: 'developers')
-Group.create(name: 'operators')
+Group.create(name: 'developers').user_ids = [1, 2]
+Group.create(name: 'operators').user_ids = [1]
 Group.create(name: 'testers')

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -17,6 +17,6 @@ Assignment.create(issue_id: 1, user_id: 1)
 Assignment.create(issue_id: 2, user_id: 1)
 Assignment.create(issue_id: 2, user_id: 2)
 
-Group.create(name: 'developers').user_ids = [1, 2]
-Group.create(name: 'operators').user_ids = [1]
+Group.create(name: 'developers')
+Group.create(name: 'operators')
 Group.create(name: 'testers')

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -16,3 +16,7 @@ User.create(name: 'hsuzuki', email: 'hsuzuki@example.com')
 Assignment.create(issue_id: 1, user_id: 1)
 Assignment.create(issue_id: 2, user_id: 1)
 Assignment.create(issue_id: 2, user_id: 2)
+
+Group.create(name: 'developers')
+Group.create(name: 'operators')
+Group.create(name: 'testers')

--- a/spec/controllers/group_users_controller_spec.rb
+++ b/spec/controllers/group_users_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe GroupUsersController, type: :controller do
+
+end

--- a/spec/controllers/group_users_controller_spec.rb
+++ b/spec/controllers/group_users_controller_spec.rb
@@ -1,5 +1,81 @@
 require 'rails_helper'
 
 RSpec.describe GroupUsersController, type: :controller do
+  shared_examples 'return_not_found_response' do
+    it 'return not found response' do
+      expect(response).to have_http_status :not_found
 
+      body = JSON.parse(response.body)
+
+      expect(body).to include('message', 'status' => 'ng', 'error_code' => 404)
+    end
+  end
+
+  describe '#show' do
+    context 'when the specified group exists' do
+      let!(:user) { create(:user) }
+      let!(:group) { create(:group).tap { |group| group.user_ids = [user.id] } }
+
+      subject(:response) { get :show, params: { group_id: group.id } }
+
+      it 'return ok and user list' do
+        expect(response).to have_http_status :ok
+
+        body = JSON.parse(response.body)
+
+        expect(body).to include('payload', 'status' => 'ok')
+
+        returned_users = body['payload']
+
+        expect(returned_users).to be_an(Array)
+        expect(returned_users.first).to include('id' => user.id)
+      end
+    end
+
+    context 'when the specified group does not exists' do
+      subject(:response) { get :show, params: { group_id: 9999 } }
+
+      it_behaves_like 'return_not_found_response'
+    end
+  end
+
+  describe '#update' do
+    context 'when the specified group exists' do
+      let(:user) { create(:user) }
+      let(:substitute_user) { create(:user) }
+      let(:group) { create(:group).tap { |group| group.user_ids = [user.id] } }
+
+      subject(:response) { put :update, params: group_attrs }
+
+      context 'when parameters are valid' do
+        let(:group_attrs) do
+          {
+            'group_id' => group.id,
+            'group' => {
+              'user_ids' => [substitute_user.id]
+            }
+          }
+        end
+
+        it 'update group and return ok' do
+          expect(response).to have_http_status :ok
+
+          body = JSON.parse(response.body)
+
+          expect(body).to include('payload', 'status' => 'ok')
+
+          returned_users = body['payload']
+
+          expect(returned_users).to be_an(Array)
+          expect(returned_users.first).to include('id' => substitute_user.id)
+        end
+      end
+    end
+
+    context 'when the specified group does not exists' do
+      subject(:response) { put :update, params: { group_id: 9999 } }
+
+      it_behaves_like 'return_not_found_response'
+    end
+  end
 end

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe GroupsController, type: :controller do
+
+end

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -1,5 +1,231 @@
 require 'rails_helper'
 
 RSpec.describe GroupsController, type: :controller do
+  shared_examples 'return_not_found_response' do
+    it 'return not found response' do
+      expect(response).to have_http_status :not_found
 
+      body = JSON.parse(response.body)
+
+      expect(body).to include('message', 'status' => 'ng', 'error_code' => 404)
+    end
+  end
+
+  shared_examples 'return_bad_request_response' do
+    it 'return bad request response' do
+      expect(response).to have_http_status :bad_request
+
+      body = JSON.parse(response.body)
+
+      expect(body).to include('message', 'status' => 'ng', 'error_code' => 400)
+    end
+  end
+
+  describe '#index' do
+    subject(:response) { get :index }
+
+    context 'when there is no group' do
+      it 'return ok and empty group list' do
+        expect(response).to have_http_status :ok
+
+        body = JSON.parse(response.body)
+
+        expect(body['status']).to eq 'ok'
+        expect(body['payload']).to be_an(Array)
+        expect(body['payload']).to be_empty
+      end
+    end
+
+    context 'when there is one group with user' do
+      let!(:user) { create(:user) }
+      let!(:group) { create(:group).tap { |group| group.user_ids = [user.id] } }
+
+      it 'return ok and group list' do
+        expect(response).to have_http_status :ok
+
+        body = JSON.parse(response.body)
+
+        expect(body['status']).to eq 'ok'
+        expect(body['payload']).to be_an(Array)
+
+        returned_group = body['payload'].find do |inner|
+          inner['id'] == group.id
+        end
+
+        expect(returned_group).to be_present
+        expect(returned_group['users']).to be_an(Array)
+        expect(returned_group['users']).to be_present
+
+        returned_user = returned_group['users'].find do |inner|
+          inner['id'] == user.id
+        end
+
+        expect(returned_user).to be_present
+      end
+    end
+  end
+
+  describe '#show' do
+    context 'when the specified group exists' do
+      let!(:user) { create(:user) }
+      let!(:group) { create(:group).tap { |group| group.user_ids = [user.id] } }
+
+      subject(:response) { get :show, params: { id: group.id } }
+
+      it 'return ok and group data' do
+        expect(response).to have_http_status :ok
+
+        body = JSON.parse(response.body)
+
+        expect(body).to include('payload', 'status' => 'ok')
+
+        returned_group = body['payload']
+
+        expect(returned_group).to be_present
+        expect(returned_group['users']).to be_an(Array)
+        expect(returned_group['users']).to be_present
+
+        returned_user = returned_group['users'].find do |inner|
+          inner['id'] == user.id
+        end
+
+        expect(returned_user).to be_present
+      end
+    end
+
+    context 'when the specified group does not exists' do
+      subject(:response) { get :show, params: { id: 9999 } }
+
+      it_behaves_like 'return_not_found_response'
+    end
+  end
+
+  describe '#create' do
+    subject(:response) { post :create, params: group_attrs }
+
+    context 'when parameters are valid' do
+      let(:user) { create(:user) }
+      let(:group_attrs) do
+        {
+          'group' => {
+            'name' => 'foo'
+          }
+        }
+      end
+
+      it 'create group and return ok' do
+        expect(response).to have_http_status :ok
+
+        body = JSON.parse(response.body)
+
+        expect(body).to include('payload', 'status' => 'ok')
+
+        returned_group = body['payload']
+
+        expect(returned_group).to be_present
+        expect(returned_group['users']).to be_an(Array)
+        expect(returned_group['users']).to be_empty
+      end
+    end
+
+    context 'when parameters are invalid' do
+      let(:group_attrs) do
+        {
+          'group' => {
+            'name' => ''
+          }
+        }
+      end
+
+      it_behaves_like 'return_bad_request_response'
+    end
+  end
+
+  describe '#update' do
+    context 'when the specified user exists' do
+      let(:user) { create(:user) }
+      let(:substitute_user) { create(:user) }
+      let(:group) { create(:group).tap { |group| group.user_ids = [user.id] } }
+
+      subject(:response) { put :update, params: group_attrs }
+
+      context 'when parameters are valid' do
+        let(:group_attr_name) { 'bar' }
+        let(:group_attrs) do
+          {
+            'id' => group.id,
+            'group' => {
+              'name' => group_attr_name
+            }
+          }
+        end
+
+        it 'update group and return ok' do
+          expect(response).to have_http_status :ok
+
+          body = JSON.parse(response.body)
+
+          expect(body).to include('payload', 'status' => 'ok')
+
+          returned_group = body['payload']
+
+          expect(returned_group).to be_present
+          expect(returned_group['name']).to eq group_attr_name
+
+          expect(returned_group['users']).to be_an(Array)
+          expect(returned_group['users'][0]).to include('id' => user.id)
+
+          expect(Group.find(group.id)).to have_attributes(name: group_attr_name)
+        end
+      end
+
+      context 'when parameters are invalid' do
+        let(:group_attrs) do
+          {
+            'id' => group.id,
+            'group' => {
+              'name' => ''
+            }
+          }
+        end
+
+        it_behaves_like 'return_bad_request_response'
+      end
+    end
+
+    context 'when the specified user does not exists' do
+      subject(:response) { put :update, params: { id: 9999 } }
+
+      it_behaves_like 'return_not_found_response'
+    end
+  end
+
+  describe '#destroy' do
+    context 'when specified user exists' do
+      let(:user) { create(:user) }
+      let(:group) { create(:group).tap { |group| group.user_ids = [user.id] } }
+
+      subject(:response) { delete :destroy, params: { id: group.id } }
+
+      it 'delete group and return ok' do
+        expect(response).to have_http_status :ok
+
+        body = JSON.parse(response.body)
+
+        expect(body).to include('payload', 'status' => 'ok')
+
+        returned_group = body['payload']
+
+        expect(returned_group).to be_present
+
+        expect { Group.find(group.id) }.to raise_error ActiveRecord::RecordNotFound
+      end
+    end
+
+    context 'when specified user does not exists' do
+      subject(:response) { delete :destroy, params: { id: 9999 } }
+
+      it_behaves_like 'return_not_found_response'
+    end
+  end
 end

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe GroupsController, type: :controller do
   end
 
   describe '#update' do
-    context 'when the specified user exists' do
+    context 'when the specified group exists' do
       let(:user) { create(:user) }
       let(:substitute_user) { create(:user) }
       let(:group) { create(:group).tap { |group| group.user_ids = [user.id] } }
@@ -193,7 +193,7 @@ RSpec.describe GroupsController, type: :controller do
       end
     end
 
-    context 'when the specified user does not exists' do
+    context 'when the specified group does not exists' do
       subject(:response) { put :update, params: { id: 9999 } }
 
       it_behaves_like 'return_not_found_response'
@@ -201,7 +201,7 @@ RSpec.describe GroupsController, type: :controller do
   end
 
   describe '#destroy' do
-    context 'when specified user exists' do
+    context 'when specified group exists' do
       let(:user) { create(:user) }
       let(:group) { create(:group).tap { |group| group.user_ids = [user.id] } }
 
@@ -222,7 +222,7 @@ RSpec.describe GroupsController, type: :controller do
       end
     end
 
-    context 'when specified user does not exists' do
+    context 'when specified group does not exists' do
       subject(:response) { delete :destroy, params: { id: 9999 } }
 
       it_behaves_like 'return_not_found_response'

--- a/spec/controllers/user_groups_controller_spec.rb
+++ b/spec/controllers/user_groups_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe UserGroupsController, type: :controller do
+
+end

--- a/spec/controllers/user_groups_controller_spec.rb
+++ b/spec/controllers/user_groups_controller_spec.rb
@@ -1,5 +1,81 @@
 require 'rails_helper'
 
 RSpec.describe UserGroupsController, type: :controller do
+  shared_examples 'return_not_found_response' do
+    it 'return not found response' do
+      expect(response).to have_http_status :not_found
 
+      body = JSON.parse(response.body)
+
+      expect(body).to include('message', 'status' => 'ng', 'error_code' => 404)
+    end
+  end
+
+  describe '#show' do
+    context 'when the specified user exists' do
+      let!(:group) { create(:group) }
+      let!(:user) { create(:user).tap { |user| user.group_ids = [group.id] } }
+
+      subject(:response) { get :show, params: { user_id: user.id } }
+
+      it 'return ok and group list' do
+        expect(response).to have_http_status :ok
+
+        body = JSON.parse(response.body)
+
+        expect(body).to include('payload', 'status' => 'ok')
+
+        returned_groups = body['payload']
+
+        expect(returned_groups).to be_an(Array)
+        expect(returned_groups.first).to include('id' => group.id)
+      end
+    end
+
+    context 'when the specified user does not exists' do
+      subject(:response) { get :show, params: { user_id: 9999 } }
+
+      it_behaves_like 'return_not_found_response'
+    end
+  end
+
+  describe '#update' do
+    context 'when the specified user exists' do
+      let(:group) { create(:group) }
+      let(:substitute_group) { create(:group) }
+      let(:user) { create(:user).tap { |user| user.group_ids = [group.id] } }
+
+      subject(:response) { put :update, params: user_attrs }
+
+      context 'when parameters are valid' do
+        let(:user_attrs) do
+          {
+            'user_id' => user.id,
+            'user' => {
+              'group_ids' => [substitute_group.id]
+            }
+          }
+        end
+
+        it 'update user and return ok' do
+          expect(response).to have_http_status :ok
+
+          body = JSON.parse(response.body)
+
+          expect(body).to include('payload', 'status' => 'ok')
+
+          returned_groups = body['payload']
+
+          expect(returned_groups).to be_an(Array)
+          expect(returned_groups.first).to include('id' => substitute_group.id)
+        end
+      end
+    end
+
+    context 'when the specified group does not exists' do
+      subject(:response) { put :update, params: { user_id: 9999 } }
+
+      it_behaves_like 'return_not_found_response'
+    end
+  end
 end

--- a/spec/factories/group_users.rb
+++ b/spec/factories/group_users.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :group_user do
+    user { nil }
+    group { nil }
+  end
+end

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :group do
+    name { "MyString" }
+  end
+end

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :group do
-    name { "MyString" }
+    name { "グループ名" }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :user do
-    name { "john doe" }
+    sequence(:name) { |i| "john doe #{i}" }
     email { "test@example.com" }
   end
 end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Group, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -1,5 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe Group, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  context 'when name is nil' do
+    subject { build(:group, name: nil) }
+    it { is_expected.not_to be_valid }
+  end
+
+  context 'when name is an empty string' do
+    subject { build(:group, name: '') }
+    it { is_expected.not_to be_valid }
+  end
 end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -10,4 +10,12 @@ RSpec.describe Group, type: :model do
     subject { build(:group, name: '') }
     it { is_expected.not_to be_valid }
   end
+
+  context 'relation group and user' do
+    let(:group) { create(:group) }
+    let(:user) { create(:user) }
+
+    subject { group.tap { |group| group.user_ids = [user.id] }.user_ids }
+    it { is_expected.to match_array([user.id]) }
+  end
 end

--- a/spec/models/group_user_spec.rb
+++ b/spec/models/group_user_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe GroupUser, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/group_user_spec.rb
+++ b/spec/models/group_user_spec.rb
@@ -1,5 +1,42 @@
 require 'rails_helper'
 
 RSpec.describe GroupUser, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:group) { create(:group) }
+  let(:user) { create(:user) }
+
+  context 'when group id and user id are valid' do
+    subject { build(:group_user, user_id: user.id, group_id: group.id) }
+    it { is_expected.to be_valid }
+  end
+
+  context 'when the pair of ids is not unique' do
+    before do
+      create(:group_user, user_id: user.id, group_id: group.id)
+    end
+
+    context 'create model instance' do
+      subject { build(:group_user, user_id: user.id, group_id: group.id) }
+      it { is_expected.to_not be_valid }
+    end
+
+    context 'create model instance and save' do
+      let(:group_user) do
+        build(:group_user, user_id: user.id, group_id: group.id).save!(validate: false)
+      end
+
+      it { expect { group_user.save!(validate: false) }.to raise_error ActiveRecord::RecordNotUnique }
+    end
+  end
+
+  context 'when there is no record with specified id' do
+    context 'does not exists in the users table' do
+      subject { build(:group_user, user_id: user.id + 1, group_id: group.id) }
+      it { is_expected.to_not be_valid }
+    end
+
+    context 'does not exists in the groups table' do
+      subject { build(:group_user, user_id: user.id, group_id: group.id + 1) }
+      it { is_expected.to_not be_valid }
+    end
+  end
 end

--- a/spec/models/group_user_spec.rb
+++ b/spec/models/group_user_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe GroupUser, type: :model do
 
     context 'create model instance and save' do
       let(:group_user) do
-        build(:group_user, user_id: user.id, group_id: group.id).save!(validate: false)
+        build(:group_user, user_id: user.id, group_id: group.id)
       end
 
       it { expect { group_user.save!(validate: false) }.to raise_error ActiveRecord::RecordNotUnique }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -47,4 +47,12 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
+  context 'relation user and group' do
+    let(:user) { create(:user) }
+    let(:group) { create(:group) }
+
+    subject { user.tap { |user| user.group_ids = [group.id] }.group_ids }
+    it { is_expected.to match_array([group.id]) }
+  end
 end


### PR DESCRIPTION
#32 に対応しました。

## 実装内容

- [x] Group モデルとマイグレーションを作成
    - [x] Group モデルのテストを作成
- [x] GroupUser モデルとマイグレーションを作成
    - [x] Group モデルと User モデルを GroupUser モデルを介してリレーションするように設定
    - [x] GroupUser モデルのテストを作成
- [x] マイグレーションを実行してスキーマを更新
- [x] Groups コントローラを作成し CRUD 処理を実装
    - [x] Groups コントローラのテストを作成
- [x] Users コントローラーのレスポンスに所属する Group の情報を含めるように修正
    - [x] Users コントローラのテストを追加
- [x] GroupUsers と UserGroups コントローラーのルートの設定
- [x] GroupUsers と UserGroups コントローラでリレーションを設定できるように実装
    - [x] GroupUsers コントローラのテストを作成
    - [x] UserGroups コントローラのテストを作成
- [x] Lint に対応


## 特筆すべき仕様

ユーザーとグループを紐付けるには、以下のいずれかの API を実行してください。

### 1. `PUT /users/:user_id/groups`

```json
{
    "user": {
        "group_ids": [1, 2]
    }
}
```

### 2. `PUT /groups/:group_id/users`

```json
{
    "group": {
        "user_ids": [1, 2]
    }
}
```
