### PR TITLE
#34 Issueにタグをつけられるようにする

### DIFF
--- a/app/controllers/issue_tags_controller.rb
+++ b/app/controllers/issue_tags_controller.rb
@@ -1,2 +1,21 @@
 class IssueTagsController < ApplicationController
+  def show
+    issue = Issue.find(params[:issue_id])
+    render_ok(issue.tags)
+  end
+
+  def update
+    issue = Issue.find(params[:issue_id])
+    if issue.update(issue_tags_params)
+      render_ok(issue.tags)
+    else
+      render_ng(400, issue.errors)
+    end
+  end
+
+  private
+
+  def issue_tags_params
+    params.require(:issue).permit(tag_ids: [])
+  end
 end

--- a/app/controllers/issue_tags_controller.rb
+++ b/app/controllers/issue_tags_controller.rb
@@ -1,0 +1,2 @@
+class IssueTagsController < ApplicationController
+end

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -1,7 +1,7 @@
 class IssuesController < ApplicationController
   def index
     @r = Issue.ransack(params[:q]).result
-    render_ok(JSON.parse(@r.includes(:users).to_json(include: :users)))
+    render_ok(JSON.parse(@r.includes(:users, :tags).to_json(include: [:users, :tags])))
   end
 
   def create

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -1,0 +1,2 @@
+class TagsController < ApplicationController
+end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -1,2 +1,43 @@
 class TagsController < ApplicationController
+  def index
+    render_ok(Tag.all)
+  end
+
+  def show
+    tag = Tag.find(params[:id])
+    render_ok(tag)
+  end
+
+  def create
+    tag = Tag.new(tag_params)
+    if tag.save
+      render_ok(tag)
+    else
+      render_ng(400, tag.errors)
+    end
+  end
+
+  def update
+    tag = Tag.find(params[:id])
+    if tag.update(tag_params)
+      render_ok(tag)
+    else
+      render_ng(400, tag.errors)
+    end
+  end
+
+  def destroy
+    tag = Tag.find(params[:id])
+    if tag.destroy
+      render_ok(tag)
+    else
+      render_ng(400, tag.errors)
+    end
+  end
+
+  private
+
+  def tag_params
+    params.require(:tag).permit(:name)
+  end
 end

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -3,6 +3,9 @@ class Issue < ApplicationRecord
   has_many :assignments # rubocop:disable Rails/HasManyOrHasOneDependent
   has_many :users, through: :assignments
 
+  has_many :issue_tags, dependent: :destroy
+  has_many :tags, through: :issue_tags
+
   validates :title, presence: true
 
   enum status: { keep: 0, problem: 1, try: 2 }

--- a/app/models/issue_tag.rb
+++ b/app/models/issue_tag.rb
@@ -1,0 +1,4 @@
+class IssueTag < ApplicationRecord
+  belongs_to :issue
+  belongs_to :tag
+end

--- a/app/models/issue_tag.rb
+++ b/app/models/issue_tag.rb
@@ -1,4 +1,6 @@
 class IssueTag < ApplicationRecord
   belongs_to :issue
   belongs_to :tag
+
+  validates :tag_id, uniqueness: { scope: :issue_id }
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,2 @@
+class Tag < ApplicationRecord
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,4 +1,6 @@
 class Tag < ApplicationRecord
   has_many :issue_tags, dependent: :destroy
   has_many :issues, through: :issue_tags
+
+  validates :name, presence: true
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,2 +1,4 @@
 class Tag < ApplicationRecord
+  has_many :issue_tags, dependent: :destroy
+  has_many :issues, through: :issue_tags
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,5 +9,6 @@ Rails.application.routes.draw do
   end
 
   resources :assignments, only: [:index, :create, :destroy]
+  resources :tags
   resources :users
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
       patch :open
       patch :close
     end
+    resource :tags, controller: 'issue_tags', only: [:show, :update]
   end
 
   resources :assignments, only: [:index, :create, :destroy]

--- a/db/migrate/20190608163122_create_tags.rb
+++ b/db/migrate/20190608163122_create_tags.rb
@@ -1,0 +1,9 @@
+class CreateTags < ActiveRecord::Migration[5.1]
+  def change
+    create_table :tags do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190608163414_create_issue_tags.rb
+++ b/db/migrate/20190608163414_create_issue_tags.rb
@@ -1,0 +1,10 @@
+class CreateIssueTags < ActiveRecord::Migration[5.1]
+  def change
+    create_table :issue_tags do |t|
+      t.references :issue, foreign_key: true
+      t.references :tag, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190608163414_create_issue_tags.rb
+++ b/db/migrate/20190608163414_create_issue_tags.rb
@@ -1,8 +1,8 @@
 class CreateIssueTags < ActiveRecord::Migration[5.1]
   def change
     create_table :issue_tags do |t|
-      t.references :issue, foreign_key: true
-      t.references :tag, foreign_key: true
+      t.references :issue, foreign_key: true, null: false
+      t.references :tag, foreign_key: true, null: false
 
       t.timestamps
 

--- a/db/migrate/20190608163414_create_issue_tags.rb
+++ b/db/migrate/20190608163414_create_issue_tags.rb
@@ -5,6 +5,8 @@ class CreateIssueTags < ActiveRecord::Migration[5.1]
       t.references :tag, foreign_key: true
 
       t.timestamps
+
+      t.index [:issue_id, :tag_id], unique: true
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190508234320) do
+ActiveRecord::Schema.define(version: 20190608163414) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,6 +25,16 @@ ActiveRecord::Schema.define(version: 20190508234320) do
     t.index ["user_id"], name: "index_assignments_on_user_id"
   end
 
+  create_table "issue_tags", force: :cascade do |t|
+    t.bigint "issue_id", null: false
+    t.bigint "tag_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["issue_id", "tag_id"], name: "index_issue_tags_on_issue_id_and_tag_id", unique: true
+    t.index ["issue_id"], name: "index_issue_tags_on_issue_id"
+    t.index ["tag_id"], name: "index_issue_tags_on_tag_id"
+  end
+
   create_table "issues", force: :cascade do |t|
     t.string "title"
     t.text "body"
@@ -34,6 +44,12 @@ ActiveRecord::Schema.define(version: 20190508234320) do
     t.datetime "deleted_at"
     t.boolean "is_closed", default: false, null: false
     t.index ["deleted_at"], name: "index_issues_on_deleted_at"
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "users", force: :cascade do |t|
@@ -48,4 +64,6 @@ ActiveRecord::Schema.define(version: 20190508234320) do
 
   add_foreign_key "assignments", "issues"
   add_foreign_key "assignments", "users"
+  add_foreign_key "issue_tags", "issues"
+  add_foreign_key "issue_tags", "tags"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -16,3 +16,6 @@ User.create(name: 'hsuzuki', email: 'hsuzuki@example.com')
 Assignment.create(issue_id: 1, user_id: 1)
 Assignment.create(issue_id: 2, user_id: 1)
 Assignment.create(issue_id: 2, user_id: 2)
+
+Tag.create(name: '急ぎ')
+Tag.create(name: '重要')

--- a/spec/controllers/issue_tags_controller_spec.rb
+++ b/spec/controllers/issue_tags_controller_spec.rb
@@ -1,5 +1,81 @@
 require 'rails_helper'
 
 RSpec.describe IssueTagsController, type: :controller do
+  shared_examples 'return_not_found_response' do
+    it 'return not found response' do
+      expect(response).to have_http_status :not_found
 
+      body = JSON.parse(response.body)
+
+      expect(body).to include('message', 'status' => 'ng', 'error_code' => 404)
+    end
+  end
+
+  describe '#show' do
+    context 'when the specified issue exists' do
+      let!(:tag) { create(:tag) }
+      let!(:issue) { create(:issue).tap { |issue| issue.tag_ids = [tag.id] } }
+
+      subject(:response) { get :show, params: { issue_id: issue.id } }
+
+      it 'return ok and tag list' do
+        expect(response).to have_http_status :ok
+
+        body = JSON.parse(response.body)
+
+        expect(body).to include('payload', 'status' => 'ok')
+
+        returned_tags = body['payload']
+
+        expect(returned_tags).to be_an(Array)
+        expect(returned_tags.first).to include('id' => tag.id)
+      end
+    end
+
+    context 'when the specified issue does not exists' do
+      subject(:response) { get :show, params: { issue_id: 9999 } }
+
+      it_behaves_like 'return_not_found_response'
+    end
+  end
+
+  describe '#update' do
+    context 'when the specified issue exists' do
+      let(:tag) { create(:tag) }
+      let(:substitute_tag) { create(:tag) }
+      let(:issue) { create(:issue).tap { |issue| issue.tag_ids = [tag.id] } }
+
+      subject(:response) { put :update, params: issue_attrs }
+
+      context 'when parameters are valid' do
+        let(:issue_attrs) do
+          {
+            'issue_id' => issue.id,
+            'issue' => {
+              'tag_ids' => [substitute_tag.id]
+            }
+          }
+        end
+
+        it 'update issue and return ok' do
+          expect(response).to have_http_status :ok
+
+          body = JSON.parse(response.body)
+
+          expect(body).to include('payload', 'status' => 'ok')
+
+          returned_tags = body['payload']
+
+          expect(returned_tags).to be_an(Array)
+          expect(returned_tags.first).to include('id' => substitute_tag.id)
+        end
+      end
+    end
+
+    context 'when the specified tag does not exists' do
+      subject(:response) { put :update, params: { issue_id: 9999 } }
+
+      it_behaves_like 'return_not_found_response'
+    end
+  end
 end

--- a/spec/controllers/issue_tags_controller_spec.rb
+++ b/spec/controllers/issue_tags_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe IssueTagsController, type: :controller do
+
+end

--- a/spec/controllers/issues_controller_spec.rb
+++ b/spec/controllers/issues_controller_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe IssuesController, type: :controller do
 
   describe '#index' do
     context 'default' do
-      let!(:issue) { create :issue }
+      let!(:tag) { create :tag }
+      let!(:issue) { create(:issue).tap { |issue| issue.tag_ids = [tag.id] } }
       let!(:user) { create :user }
       let!(:user_deleted) { create(:user, name: 'deleted_user') }
       let!(:assignment) { create(:assignment, user_id: user.id, issue_id: issue.id) }
@@ -23,6 +24,7 @@ RSpec.describe IssuesController, type: :controller do
       it { expect(JSON.parse(subject.body)['payload'].map { |d| d['id'] }).to include issue.id }
       it { expect(JSON.parse(subject.body)['payload'].select { |d| d['id'] == issue.id }[0]['users'][0]['id']).to eq user.id }
       it { expect(JSON.parse(subject.body)['payload'].select { |d| d['id'] == issue.id }[0]['users'][1]['id']).to eq user_deleted.id }
+      it { expect(JSON.parse(subject.body)['payload'].select { |d| d['id'] == issue.id }[0]['tags'][0]['id']).to eq tag.id }
     end
     context 'filter by status' do
       let!(:issues_searched) { create_list :issue, 10, title: 'the string to be searched', status: :keep }

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe TagsController, type: :controller do
+
+end

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -1,5 +1,205 @@
 require 'rails_helper'
 
 RSpec.describe TagsController, type: :controller do
+  shared_examples 'return_not_found_response' do
+    it 'return not found response' do
+      expect(response).to have_http_status :not_found
 
+      body = JSON.parse(response.body)
+
+      expect(body).to include('message', 'status' => 'ng', 'error_code' => 404)
+    end
+  end
+
+  shared_examples 'return_bad_request_response' do
+    it 'return bad request response' do
+      expect(response).to have_http_status :bad_request
+
+      body = JSON.parse(response.body)
+
+      expect(body).to include('message', 'status' => 'ng', 'error_code' => 400)
+    end
+  end
+
+  describe '#index' do
+    subject(:response) { get :index }
+
+    context 'when there is no tag' do
+      it 'return ok and empty tag list' do
+        expect(response).to have_http_status :ok
+
+        body = JSON.parse(response.body)
+
+        expect(body['status']).to eq 'ok'
+        expect(body['payload']).to be_an(Array)
+        expect(body['payload']).to be_empty
+      end
+    end
+
+    context 'when there is one tag with issue' do
+      let!(:tag) { create(:tag) }
+
+      it 'return ok and tag list' do
+        expect(response).to have_http_status :ok
+
+        body = JSON.parse(response.body)
+
+        expect(body['status']).to eq 'ok'
+        expect(body['payload']).to be_an(Array)
+
+        returned_tag = body['payload'].find do |inner|
+          inner['id'] == tag.id
+        end
+
+        expect(returned_tag).to be_present
+      end
+    end
+  end
+
+  describe '#show' do
+    context 'when the specified tag exists' do
+      let!(:tag) { create(:tag) }
+
+      subject(:response) { get :show, params: { id: tag.id } }
+
+      it 'return ok and tag data' do
+        expect(response).to have_http_status :ok
+
+        body = JSON.parse(response.body)
+
+        expect(body).to include('payload', 'status' => 'ok')
+
+        returned_tag = body['payload']
+
+        expect(returned_tag).to be_present
+        expect(returned_tag['id']).to eq tag.id
+      end
+    end
+
+    context 'when the specified tag does not exists' do
+      subject(:response) { get :show, params: { id: 9999 } }
+
+      it_behaves_like 'return_not_found_response'
+    end
+  end
+
+  describe '#create' do
+    subject(:response) { post :create, params: tag_attrs }
+
+    context 'when parameters are valid' do
+      let(:tag_attrs) do
+        {
+          'tag' => {
+            'name' => 'foo'
+          }
+        }
+      end
+
+      it 'create tag and return ok' do
+        expect(response).to have_http_status :ok
+
+        body = JSON.parse(response.body)
+
+        expect(body).to include('payload', 'status' => 'ok')
+
+        returned_tag = body['payload']
+
+        expect(returned_tag).to be_present
+      end
+    end
+
+    context 'when parameters are invalid' do
+      let(:tag_attrs) do
+        {
+          'tag' => {
+            'name' => ''
+          }
+        }
+      end
+
+      it_behaves_like 'return_bad_request_response'
+    end
+  end
+
+  describe '#update' do
+    context 'when the specified tag exists' do
+      let(:tag) { create(:tag) }
+
+      subject(:response) { put :update, params: tag_attrs }
+
+      context 'when parameters are valid' do
+        let(:tag_attr_name) { 'bar' }
+        let(:tag_attrs) do
+          {
+            'id' => tag.id,
+            'tag' => {
+              'name' => tag_attr_name
+            }
+          }
+        end
+
+        it 'update tag and return ok' do
+          expect(response).to have_http_status :ok
+
+          body = JSON.parse(response.body)
+
+          expect(body).to include('payload', 'status' => 'ok')
+
+          returned_tag = body['payload']
+
+          expect(returned_tag).to be_present
+          expect(returned_tag['name']).to eq tag_attr_name
+
+          expect(Tag.find(tag.id)).to have_attributes(name: tag_attr_name)
+        end
+      end
+
+      context 'when parameters are invalid' do
+        let(:tag_attrs) do
+          {
+            'id' => tag.id,
+            'tag' => {
+              'name' => ''
+            }
+          }
+        end
+
+        it_behaves_like 'return_bad_request_response'
+      end
+    end
+
+    context 'when the specified tag does not exists' do
+      subject(:response) { put :update, params: { id: 9999 } }
+
+      it_behaves_like 'return_not_found_response'
+    end
+  end
+
+  describe '#destroy' do
+    context 'when specified tag exists' do
+      let(:tag) { create(:tag) }
+
+      subject(:response) { delete :destroy, params: { id: tag.id } }
+
+      it 'delete tag and return ok' do
+        expect(response).to have_http_status :ok
+
+        body = JSON.parse(response.body)
+
+        expect(body).to include('payload', 'status' => 'ok')
+
+        returned_tag = body['payload']
+
+        expect(returned_tag).to be_present
+
+        expect { Tag.find(tag.id) }.to raise_error ActiveRecord::RecordNotFound
+      end
+    end
+
+    context 'when specified tag does not exists' do
+      subject(:response) { delete :destroy, params: { id: 9999 } }
+
+      it_behaves_like 'return_not_found_response'
+    end
+  end
 end

--- a/spec/factories/issue_tags.rb
+++ b/spec/factories/issue_tags.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :issue_tag do
+    issue { nil }
+    tag { nil }
+  end
+end

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :tag do
+    name { "MyString" }
+  end
+end

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :tag do
-    name { "MyString" }
+    name { "タグ名" }
   end
 end

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -5,4 +5,12 @@ RSpec.describe Issue, type: :model do
     subject { build(:issue, title: '') }
     it { expect(subject).not_to be_valid }
   end
+
+  context 'relation issue and tag' do
+    let(:issue) { create(:issue) }
+    let(:tag) { create(:tag) }
+
+    subject { issue.tap { |issue| issue.tag_ids = [tag.id] }.tag_ids }
+    it { is_expected.to match_array([tag.id]) }
+  end
 end

--- a/spec/models/issue_tag_spec.rb
+++ b/spec/models/issue_tag_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe IssueTag, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/issue_tag_spec.rb
+++ b/spec/models/issue_tag_spec.rb
@@ -1,5 +1,42 @@
 require 'rails_helper'
 
 RSpec.describe IssueTag, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:issue) { create(:issue) }
+  let(:tag) { create(:tag) }
+
+  context 'when issue id and tag id are valid' do
+    subject { build(:issue_tag, tag_id: tag.id, issue_id: issue.id) }
+    it { is_expected.to be_valid }
+  end
+
+  context 'when the pair of ids is not unique' do
+    before do
+      create(:issue_tag, tag_id: tag.id, issue_id: issue.id)
+    end
+
+    context 'create model instance' do
+      subject { build(:issue_tag, tag_id: tag.id, issue_id: issue.id) }
+      it { is_expected.to_not be_valid }
+    end
+
+    context 'create model instance and save' do
+      let(:issue_tag) do
+        build(:issue_tag, tag_id: tag.id, issue_id: issue.id)
+      end
+
+      it { expect { issue_tag.save!(validate: false) }.to raise_error ActiveRecord::RecordNotUnique }
+    end
+  end
+
+  context 'when there is no record with specified id' do
+    context 'does not exists in the tags table' do
+      subject { build(:issue_tag, tag_id: tag.id + 1, issue_id: issue.id) }
+      it { is_expected.to_not be_valid }
+    end
+
+    context 'does not exists in the issues table' do
+      subject { build(:issue_tag, tag_id: tag.id, issue_id: issue.id + 1) }
+      it { is_expected.to_not be_valid }
+    end
+  end
 end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Tag, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -10,4 +10,12 @@ RSpec.describe Tag, type: :model do
     subject { build(:tag, name: '') }
     it { is_expected.not_to be_valid }
   end
+
+  context 'relation tag and issue' do
+    let(:tag) { create(:tag) }
+    let(:issue) { create(:issue) }
+
+    subject { tag.tap { |tag| tag.issue_ids = [issue.id] }.issue_ids }
+    it { is_expected.to match_array([issue.id]) }
+  end
 end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -1,5 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe Tag, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  context 'when name is nil' do
+    subject { build(:tag, name: nil) }
+    it { is_expected.not_to be_valid }
+  end
+
+  context 'when name is an empty string' do
+    subject { build(:tag, name: '') }
+    it { is_expected.not_to be_valid }
+  end
 end


### PR DESCRIPTION
#34 に対応しました。

## 実装内容

- [x] Tag モデルとマイグレーションを作成
    - [x] Tag モデルのテストを作成
- [x] IssueTag モデルとマイグレーションを作成
    - [x] Tag モデルと Issue モデルを IssueTag モデルを介してリレーションするように設定
    - [x] IssueTag モデルのテストを作成
- [x] マイグレーションを実行してスキーマを更新
- [x] Tags コントローラを作成し、ルートを設定し、CRUD 処理を実装
    - [x] Tags コントローラのテストを作成
- [x] Issues コントローラーのレスポンスに割り当てられた Tag の情報を含めるように修正
    - [x] Issues コントローラのテストを追加
- [x] IssueTags コントローラーの実装とルートの設定
    - [x] IssueTags コントローラのテストを作成
- [x] Lint に対応


## 特筆すべき仕様

Issue とタグを紐付けるには、以下の API を実行してください。

### `PUT /issues/:issue_id/tags`

```json
{
    "issue": {
        "tag_ids": [1, 2]
    }
}
```
